### PR TITLE
docs: fix typo in a section describing search API

### DIFF
--- a/docs/sources/http_api/dashboard.md
+++ b/docs/sources/http_api/dashboard.md
@@ -232,7 +232,7 @@ Get all tags of dashboards
 Status Codes:
 
 - **query** – Search Query
-- **tags** – Tags to use
+- **tag** – Tag to use
 - **starred** – Flag indicating if only starred Dashboards should be returned
 - **tagcloud** - Flag indicating if a tagcloud should be returned
 


### PR DESCRIPTION
The API document describes Search Dashboards API accepts a parameter named `tags`.

But actually, the API accept not `tags` but `tag` as a parameter.

https://github.com/grafana/grafana/blob/master/pkg/api/search.go#L14

It looks that the documentation should be fixed.